### PR TITLE
Defend against broken promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,15 @@ module.exports = function maybe (cb, promise) {
   if (cb) {
     promise
       .then(function (result) {
-        next(function () { cb(null, result) })
+        next(() => {
+          cb && cb(null, result)
+          cb = undefined
+        })
       }, function (err) {
-        next(function () { cb(err) })
+        next(() => {
+          cb && cb(err)
+          cb = undefined
+        })
       })
     return undefined
   }

--- a/index.js
+++ b/index.js
@@ -8,12 +8,12 @@ module.exports = function maybe (cb, promise) {
   if (cb) {
     promise
       .then(function (result) {
-        next(() => {
+        next(function () {
           cb && cb(null, result)
           cb = undefined
         })
       }, function (err) {
-        next(() => {
+        next(function () {
           cb && cb(err)
           cb = undefined
         })


### PR DESCRIPTION
Convo from: https://github.com/limulus/call-me-maybe/issues/5

@limulus so in order to make the bug appear I needed to create a broken promise implementation.

This has the nice side-effect that once the callback was called the reference is erased, which will allow the garbage collector to clean the object and thus prevent memory leaks.